### PR TITLE
Add env.example for easier configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ security updates are installed automatically.
 
 The backup script runs from the virtual environment created in the
 [Getting started with Python](#getting-started-with-python) section.
-Activate the environment and then configure your mail settings:
+Activate the environment and then configure your mail settings.
 
-Create a file named `.env.local` next to the script containing your mail
-settings:
+Copy the provided `env.example` to `.env.local` next to the script and
+adjust the values to match your environment:
 
 ```
 FROM_ADDR=you@example.com

--- a/env.example
+++ b/env.example
@@ -1,0 +1,9 @@
+# Example environment variables for pull_vaultwarden_backups.py
+# Copy this file to .env.local and adjust the values as needed.
+FROM_ADDR=you@example.com
+TO_ADDR=you@example.com
+SMTP_SERVER=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=your_user
+SMTP_PASS=your_pass
+MAIL_SUBJECT=Vaultwarden Backup Summary


### PR DESCRIPTION
## Summary
- provide an `env.example` with sample environment variables
- reference the example file in the README

## Testing
- `python3 -m py_compile pull_vaultwarden_backups.py`
- `sh -n setup_unattended_upgrades.sh`
- `pytest -q`
- `shellcheck setup_unattended_upgrades.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e89b53800832ca1fe355bc778ea3b