### PR TITLE
Improve unattended-upgrades documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,24 @@ The script installs the required packages, enables the systemd service and
 creates a basic `/etc/apt/apt.conf.d/20auto-upgrades` configuration so that
 security updates are installed automatically.
 
+### Balancing security and uptime
+
+`setup_unattended_upgrades.sh` reboots the host whenever a package requires it.
+This keeps the system as secure as possible but may reduce uptime. The
+behaviour can be tuned using environment variables when running the script:
+
+```bash
+# disable reboots after upgrades
+AUTO_REBOOT=0 ./setup_unattended_upgrades.sh
+
+# or change the reboot time (defaults to 02:00)
+AUTO_REBOOT_TIME=04:00 ./setup_unattended_upgrades.sh
+```
+
+Set `AUTO_REBOOT` to `1` (the default) to reboot automatically. Adjust
+`AUTO_REBOOT_TIME` to a suitable maintenance window so updates apply promptly
+without unexpected downtime.
+
 ## Notification script
 
 The backup script runs from the virtual environment created in the

--- a/setup_unattended_upgrades.sh
+++ b/setup_unattended_upgrades.sh
@@ -2,6 +2,20 @@
 set -euo pipefail
 
 # Install and enable unattended-upgrades on Debian 12
+#
+# The behaviour can be tuned through the following environment variables:
+#   AUTO_REBOOT="1"   - automatically reboot if required after upgrades.
+#                       Set to "0" to disable automatic rebooting.
+#   AUTO_REBOOT_TIME   - time of day for the reboot (default "02:00").
+#
+# These allow you to balance security (installing updates and rebooting as
+# soon as possible) against uptime (avoiding unexpected reboots).
+#
+# Example:
+#   AUTO_REBOOT=0 ./setup_unattended_upgrades.sh
+
+AUTO_REBOOT="${AUTO_REBOOT:-1}"
+AUTO_REBOOT_TIME="${AUTO_REBOOT_TIME:-02:00}"
 sudo apt-get update
 sudo apt-get install -y unattended-upgrades apt-listchanges
 
@@ -17,4 +31,11 @@ APT::Periodic::Update-Package-Lists "1";
 APT::Periodic::Unattended-Upgrade "1";
 CFG
 
+# Configure reboot behaviour
+sudo tee /etc/apt/apt.conf.d/51auto-reboot >/dev/null <<CFG
+Unattended-Upgrade::Automatic-Reboot "${AUTO_REBOOT}";
+Unattended-Upgrade::Automatic-Reboot-Time "${AUTO_REBOOT_TIME}";
+CFG
+
 echo "Unattended-upgrades installed and configured."
+


### PR DESCRIPTION
## Summary
- document reboot policy configuration for unattended-upgrades
- allow configuring automatic reboot time in the setup script

## Testing
- `python3 -m py_compile pull_vaultwarden_backups.py`
- `bash -n setup_unattended_upgrades.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e8c826110832c9d5f8426efb54720