### PR TITLE
Fix script name reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository provides two scripts:
 
 1. **setup_unattended_upgrades.sh** – installs and enables automatic security
    updates on Debian or Ubuntu.
-2. **pull_vaultwarden_backups.py** – optionally sends a short status email
+2. **system_status_email.py** – optionally sends a short status email
    about updates and system resources.
    
 ## Setting up unattended upgrades
@@ -86,7 +86,7 @@ pip install -r requirements.txt
 ```
 
 Once activated, the `venv` directory contains the Python interpreter and
-packages needed to run `pull_vaultwarden_backups.py`.
+packages needed to run `system_status_email.py`.
 
 ### Configuring mail
 


### PR DESCRIPTION
## Summary
- rename references to `system_status_email.py` in README

## Testing
- `python3 -m py_compile system_status_email.py`
- `bash -n setup_unattended_upgrades.sh`


------
https://chatgpt.com/codex/tasks/task_e_685e96805014832ca61f73abb4b50296